### PR TITLE
🐛 Fixes Date() returning incorrect time.

### DIFF
--- a/date_discord.go
+++ b/date_discord.go
@@ -5,6 +5,6 @@ package snowflake
 import "time"
 
 func (s Snowflake) Date() time.Time {
-	var epoch uint64 = (uint64(s) >> uint64(22)) + EpochDiscord
-	return time.Unix(int64(epoch), 0)
+	var epoch = (uint64(s) >> uint64(22)) + EpochDiscord
+	return time.Unix(int64(epoch) / 1000, 0)
 }

--- a/snowflake_test.go
+++ b/snowflake_test.go
@@ -142,7 +142,7 @@ func TestJSONMarshalling(t *testing.T) {
 
 func TestDate(t *testing.T) {
 	s := NewSnowflake(228846961774559232)
-	if s.Date().Unix() != 1474631767458 {
+	if s.Date().Unix() != 1474631767 {
 		t.Error("date is incorrect")
 	}
 }


### PR DESCRIPTION
Timestamp was passed as millisecond while time.Unix expects seconds